### PR TITLE
Add ratio to server statistics

### DIFF
--- a/src/components/details.tsx
+++ b/src/components/details.tsx
@@ -337,6 +337,14 @@ function Stats(props: { stats: SessionStatEntry }) {
                 <td>{bytesToHumanReadableStr(props.stats.uploadedBytes)}</td>
             </tr>
             <tr>
+                <td>Ratio</td>
+                <td>
+                    {props.stats.downloadedBytes === 0
+                        ? "∞"
+                        : (props.stats.uploadedBytes / props.stats.downloadedBytes).toFixed(2)}
+                </td>
+            </tr>
+            <tr>
                 <td>Files added</td>
                 <td>{props.stats.filesAdded}</td>
             </tr>


### PR DESCRIPTION
The implementation is more or less the same as `UploadRatioField` in `TorrentTable`:
https://github.com/openscopeproject/TrguiNG/blob/152724a5f2b82cbeacea80aa2a92cd93f5557a98/src/components/tables/torrenttable.tsx#L219-L227