### PR TITLE
Improve files table UX (fixes #121):

### DIFF
--- a/src/css/torrenttable.css
+++ b/src/css/torrenttable.css
@@ -84,6 +84,16 @@
     box-shadow: inset 0 0 0 9999px rgba(133, 133, 133, 0.1);
 }
 
+.torrent-table .tr.descendant-selected {
+    background-color: rgb(50, 80, 170);
+    color: white;
+    box-shadow: inset 0 0 0 9999px rgba(133, 133, 133, 0.7);
+}
+
+.torrent-table .tr.descendant-selected:nth-child(odd) {
+    box-shadow: inset 0 0 0 9999px rgba(133, 133, 133, 0.8);
+}
+
 .resizer {
     display: block;
     background: rgba(124, 124, 124, 0.4);

--- a/src/trutil.ts
+++ b/src/trutil.ts
@@ -227,3 +227,7 @@ const badChars = /[<>:"\\/|?*]/g;
 export function fileSystemSafeName(name: string) {
     return name.replace(badChars, "_");
 }
+
+export function * chainedIterables<T>(...iterables: Array<Iterable<T>>) {
+    for (const iterable of iterables) yield * iterable;
+}


### PR DESCRIPTION
- Add visual indication to deselected directories with selected subrows
- Automatically deselect directories whenever their children are deselected
- Automatically select directories as soon as all of their children are selected
- Change Ctrl-A behavior so that it only selects entries that match the entered search terms
- Deselect entries that become hidden while using the search bar

Fair warning: this makes the issue with not being able to perform the context menu actions "Open" and "Open folder", when multiple entries are selected, just a tiny bit worse for single-file directories, because when you right click the file, the directory gets automatically selected.
When it comes to my opinion on how to fix that, I think it'd be OK to make these context menu entries apply only to the row that was actually right-clicked.