### PR TITLE
Display free disk space below directory pickers (Add & Move torrent)

### DIFF
--- a/src/components/modals/move.tsx
+++ b/src/components/modals/move.tsx
@@ -29,8 +29,8 @@ export function MoveModal(props: ModalState) {
     const serverSelected = useServerSelectedTorrents();
     const [moveData, setMoveData] = useState<boolean>(true);
 
-    const location = useTorrentLocation();
-    const { setPath } = location;
+    const location = useTorrentLocation({ freeSpaceQueryEnabled: props.opened });
+    const { immediateSetPath } = location;
 
     const changeDirectory = useTorrentChangeDirectory();
 
@@ -62,12 +62,12 @@ export function MoveModal(props: ModalState) {
     }, [serverData.torrents, serverSelected]);
 
     useEffect(() => {
-        if (props.opened) setPath(calculateInitialLocation());
-    }, [props.opened, setPath, calculateInitialLocation]);
+        if (props.opened) immediateSetPath(calculateInitialLocation());
+    }, [props.opened, immediateSetPath, calculateInitialLocation]);
 
     return <>
         {props.opened &&
-            <HkModal opened={props.opened} onClose={props.close} title="Move torrents" centered size="lg">
+            <HkModal opened onClose={props.close} title="Move torrents" centered size="lg">
                 <Divider my="sm" />
                 <Text mb="md">Enter new location for</Text>
                 <TorrentsNames />

--- a/src/queries.ts
+++ b/src/queries.ts
@@ -345,6 +345,19 @@ export function useBandwidthGroups(enabled: boolean) {
     });
 }
 
+export function useFreeSpace(enabled: boolean, path: string) {
+    const serverConfig = useContext(ServerConfigContext);
+    const client = useTransmissionClient();
+
+    return useQuery({
+        queryKey: [serverConfig.name, "free-space", path],
+        refetchInterval: 5000,
+        staleTime: 1000,
+        enabled,
+        queryFn: useCallback(async () => await client.getFreeSpace(path), [client, path]),
+    });
+}
+
 export function useFileTree(name: string, fileTree: CachedFileTree) {
     const initialData = useMemo(() => fileTree.getView(), [fileTree]);
     return useQuery({

--- a/src/rpc/client.ts
+++ b/src/rpc/client.ts
@@ -18,7 +18,7 @@
 
 import { Buffer } from "buffer";
 
-import type { PriorityNumberType, SessionAllFieldsType, SessionStatistics, TorrentFieldsType } from "./transmission";
+import type { FreeSpace, PriorityNumberType, SessionAllFieldsType, SessionStatistics, TorrentFieldsType } from "./transmission";
 import { SessionAllFields, SessionFields, TorrentAllFields } from "./transmission";
 import type { ServerConnection } from "../config";
 import type { BandwidthGroup, TorrentBase } from "./torrent";
@@ -392,6 +392,15 @@ export class TransmissionClient {
             console.log(response);
             throw new Error(`Server returned error: ${response.status} (${response.statusText})`);
         }
+    }
+
+    async getFreeSpace(path: string): Promise<FreeSpace> {
+        const request = {
+            method: "free-space",
+            arguments: { path },
+        };
+
+        return (await this._sendRpc(request)).arguments;
     }
 }
 

--- a/src/rpc/transmission.ts
+++ b/src/rpc/transmission.ts
@@ -332,3 +332,9 @@ export const BandwidthGroupFields = [
 ] as const;
 
 export type BandwidthGroupFieldType = typeof BandwidthGroupFields[number];
+
+export interface FreeSpace {
+    path: string, // same as the Request argument
+    ["size-bytes"]: number, // the size, in bytes, of the free space in that directory
+    total_size: number, // the total capacity, in bytes, of that directory
+}


### PR DESCRIPTION
<img src="https://github.com/openscopeproject/TrguiNG/assets/53523617/acfe0916-3ac6-4f70-ba77-6ceab2de2cf4" width="50%">

Shown in red if not enough free space is available:
<img src="https://github.com/openscopeproject/TrguiNG/assets/53523617/bab5eed0-b4d0-44ff-955a-c2386a3e4694" width="50%">

I've hardcoded the `refetchInterval` to 5 seconds. Should I make it configurable?
I had some doubts whether the implementation should try to be "smart" about the paths or just call the RPC method with whatever path we've got and don't care about it.
For example, an empty string passed as the path returns an error with transmission running on Windows. Not sure about other platforms.
Also, inexistent directories will also return an error, so we could potentially traverse the path upward until we get something, but this gets messy once we consider the possibility of the path containing symlinks.
So this would perhaps better be fixed in transmission itself, and not in a GUI client.