### PR TITLE
U/D field small tune up

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 node_modules
 dist
 .vscode
+.idea
 webpack-report.html
 tests/manual.torrent
 *bkp

--- a/src/components/tables/torrenttable.tsx
+++ b/src/components/tables/torrenttable.tsx
@@ -221,7 +221,9 @@ function UploadRatioField(props: TableFieldProps) {
         <div style={{ width: "100%", textAlign: "right" }}>
             {props.torrent.downloadedEver === 0
                 ? "∞"
-                : (props.torrent.uploadedEver / props.torrent.downloadedEver).toFixed(2)}
+                : props.torrent.uploadedEver === 0
+                    ? "-"
+                    : (props.torrent.uploadedEver / props.torrent.downloadedEver).toFixed(2)}
         </div>
     );
 }


### PR DESCRIPTION
Make different view(instead of zero) in U/D field for never uploaded torrents

here is the difference
zeros is just small amount uploaded but it means that at least someone asked for it
dashes means no one needs it
Useful in case of cleanup old torrents

I've put ratio close to it to see the difference but in general ratio column will be hidden

<img width="512" alt="Screenshot 2024-01-05 at 15 15 47" src="https://github.com/openscopeproject/TrguiNG/assets/1858880/537172c7-bd0d-428b-936e-2525db06db20">
