### PR TITLE
Get rid of infinity sign in U/D

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 node_modules
 dist
 .vscode
+.idea
 webpack-report.html
 tests/manual.torrent
 *bkp

--- a/src/components/tables/torrenttable.tsx
+++ b/src/components/tables/torrenttable.tsx
@@ -221,7 +221,9 @@ function UploadRatioField(props: TableFieldProps) {
         <div style={{ width: "100%", textAlign: "right" }}>
             {props.torrent.downloadedEver === 0
                 ? "∞"
-                : (props.torrent.uploadedEver / props.torrent.downloadedEver).toFixed(2)}
+                : props.torrent.uploadedEver === 0
+                    ? "-"
+                    : (props.torrent.uploadedEver / props.torrent.downloadedEver).toFixed(2)}
         </div>
     );
 }

--- a/src/components/tables/torrenttable.tsx
+++ b/src/components/tables/torrenttable.tsx
@@ -219,10 +219,10 @@ function PositiveNumberField(props: TableFieldProps) {
 function UploadRatioField(props: TableFieldProps) {
     return (
         <div style={{ width: "100%", textAlign: "right" }}>
-            {props.torrent.downloadedEver === 0
-                ? "∞"
-                : props.torrent.uploadedEver === 0
-                    ? "-"
+            {props.torrent.uploadedEver === 0
+                ? "-"
+                : props.torrent.downloadedEver === 0
+                    ? "∞"
                     : (props.torrent.uploadedEver / props.torrent.downloadedEver).toFixed(2)}
         </div>
     );

--- a/src/components/tables/torrenttable.tsx
+++ b/src/components/tables/torrenttable.tsx
@@ -220,8 +220,8 @@ function UploadRatioField(props: TableFieldProps) {
     return (
         <div style={{ width: "100%", textAlign: "right" }}>
             {props.torrent.uploadedEver === 0
-                    ? "-"
-                    : (props.torrent.uploadedEver / props.torrent.downloadedEver).toFixed(2)}
+                ? "-"
+                : (props.torrent.uploadedEver / props.torrent.downloadedEver).toFixed(2)}
         </div>
     );
 }

--- a/src/components/tables/torrenttable.tsx
+++ b/src/components/tables/torrenttable.tsx
@@ -219,9 +219,11 @@ function PositiveNumberField(props: TableFieldProps) {
 function UploadRatioField(props: TableFieldProps) {
     return (
         <div style={{ width: "100%", textAlign: "right" }}>
-            {props.torrent.uploadedEver === 0
-                ? "-"
-                : (props.torrent.uploadedEver / props.torrent.downloadedEver).toFixed(2)}
+            {props.torrent.downloadedEver === 0
+                ? "∞"
+                : props.torrent.uploadedEver === 0
+                    ? "-"
+                    : (props.torrent.uploadedEver / props.torrent.downloadedEver).toFixed(2)}
         </div>
     );
 }

--- a/src/components/tables/torrenttable.tsx
+++ b/src/components/tables/torrenttable.tsx
@@ -219,9 +219,7 @@ function PositiveNumberField(props: TableFieldProps) {
 function UploadRatioField(props: TableFieldProps) {
     return (
         <div style={{ width: "100%", textAlign: "right" }}>
-            {props.torrent.downloadedEver === 0
-                ? "∞"
-                : props.torrent.uploadedEver === 0
+            {props.torrent.uploadedEver === 0
                     ? "-"
                     : (props.torrent.uploadedEver / props.torrent.downloadedEver).toFixed(2)}
         </div>

--- a/src/components/tables/torrenttable.tsx
+++ b/src/components/tables/torrenttable.tsx
@@ -93,7 +93,7 @@ const AllFields: readonly TableField[] = [
         name: "uploadedEver",
         label: "U/D",
         component: UploadRatioField,
-        accessorFn: (t) => t.uploadedEver / t.downloadedEver,
+        accessorFn: (t) => t.uploadedEver === 0 ? 0 : t.uploadedEver / t.downloadedEver,
         columnId: "simpleRatio",
         requiredFields: ["uploadedEver", "downloadedEver"] as TorrentFieldsType[],
     },


### PR DESCRIPTION
I've just made this PR but then figured out that we don't need the infinity sign at all.
We can see not loaded torrents by many others marks like empty bar or status icon

https://github.com/openscopeproject/TrguiNG/pull/135

Maybe not merge it for now because I trying to understand how to provide custom sorting for columns with `accessorFn`.
Most of them sorting in some unpredictable way

Could you help with some manuals?
I'm not coding ts at all, just raw js a little. My main langs is java/c#.