### PR TITLE
Add "Show global speeds" toggle to status bar context menu (fixes #143)

### DIFF
--- a/src/components/server.tsx
+++ b/src/components/server.tsx
@@ -249,6 +249,7 @@ export function Server({ hostname, tabsRef }: ServerProps) {
                     filteredTorrents,
                     selectedTorrents,
                     hostname,
+                    torrents: torrents ?? [],
                 }} />
             </Box>
         </Flex>

--- a/src/config.ts
+++ b/src/config.ts
@@ -141,6 +141,7 @@ interface Settings {
         statusFiltersVisibility: StatusFiltersVisibility,
         compactDirectories: boolean,
         statusBarSections: SectionsVisibility<StatusbarSectionName>,
+        statusBarGlobalSpeeds: boolean,
         showFiltersPanel: boolean,
         showDetailsPanel: boolean,
         detailsTabs: SectionsVisibility<DetailsSectionsName>,
@@ -248,6 +249,7 @@ const DefaultSettings: Settings = {
             section,
             visible: true,
         })),
+        statusBarGlobalSpeeds: false,
         showFiltersPanel: true,
         showDetailsPanel: true,
         detailsTabs: DetailsSections.map((section) => ({


### PR DESCRIPTION
![trguing_CtyZNa9wG7](https://github.com/openscopeproject/TrguiNG/assets/53523617/b5a8441e-8ac4-47be-ac3f-963c7d106bfa)
Note: also affects the speeds displayed in the title of the tab when in WebUI mode.