### PR TITLE
Prevent scrolling the Name column into view when focusing rows in tables

### DIFF
--- a/src/components/tables/common.tsx
+++ b/src/components/tables/common.tsx
@@ -659,7 +659,7 @@ export function EditableNameField(props: EditableNameFieldProps) {
         if (ref.current != null) {
             const row = ref.current.parentNode?.parentNode as HTMLDivElement;
             row.onfocus = () => {
-                ref.current?.focus();
+                ref.current?.focus({ preventScroll: true });
             };
             return () => { row.onfocus = null; };
         }


### PR DESCRIPTION
Fixes #179

For browsers that don't support this option, it is technically possible to prevent the scroll by restoring the `scrollLeft` property after calling `.focus()`, but this needs to be done on the `.torrent-table-rows` div, which is two `.parentNode`s above.
I don't really think that's necessary, so I didn't do it.