### PR TITLE
Colorful + animated progress bars

### DIFF
--- a/src/components/details.tsx
+++ b/src/components/details.tsx
@@ -18,7 +18,7 @@
 
 import React, { memo, useCallback, useContext, useEffect, useMemo, useState } from "react";
 import type { Torrent, TrackerStats } from "../rpc/torrent";
-import { bytesToHumanReadableStr, ensurePathDelimiter, fileSystemSafeName, secondsToHumanReadableStr, timestampToDateString, torrentProgressbarVariant } from "../trutil";
+import { bytesToHumanReadableStr, ensurePathDelimiter, fileSystemSafeName, secondsToHumanReadableStr, timestampToDateString, torrentProgressbarStyle } from "../trutil";
 import { FileTreeTable, useUnwantedFiles } from "./tables/filetreetable";
 import { PiecesCanvas } from "./piecescanvas";
 import { ProgressBar } from "./progressbar";
@@ -59,8 +59,7 @@ function DownloadBar(props: { torrent: Torrent }) {
     const config = useContext(ConfigContext);
     const now = Math.floor(percent * 1000);
     const nowStr = `${prefix}: ${now / 10}%`;
-    const active = props.torrent.rateDownload > 0 || props.torrent.rateUpload > 0;
-    const variant = torrentProgressbarVariant(props, config, active);
+    const progressbarStyle = torrentProgressbarStyle(props.torrent, config);
 
     return (
         <Box w="100%" my="0.5rem">
@@ -68,8 +67,7 @@ function DownloadBar(props: { torrent: Torrent }) {
                 now={now}
                 max={1000}
                 label={nowStr}
-                animate={config.values.interface.animatedProgressbars && active}
-                variant={variant}
+                {...progressbarStyle}
             />
         </Box>
     );

--- a/src/components/details.tsx
+++ b/src/components/details.tsx
@@ -18,10 +18,9 @@
 
 import React, { memo, useCallback, useContext, useEffect, useMemo, useState } from "react";
 import type { Torrent, TrackerStats } from "../rpc/torrent";
-import { bytesToHumanReadableStr, ensurePathDelimiter, fileSystemSafeName, secondsToHumanReadableStr, timestampToDateString } from "../trutil";
+import { bytesToHumanReadableStr, ensurePathDelimiter, fileSystemSafeName, secondsToHumanReadableStr, timestampToDateString, torrentProgressbarVariant } from "../trutil";
 import { FileTreeTable, useUnwantedFiles } from "./tables/filetreetable";
 import { PiecesCanvas } from "./piecescanvas";
-import type { ProgressBarVariant } from "./progressbar";
 import { ProgressBar } from "./progressbar";
 import { DateField, LabelsField, StatusField, TrackerField } from "./tables/torrenttable";
 import { TrackersTable } from "./tables/trackertable";
@@ -61,31 +60,7 @@ function DownloadBar(props: { torrent: Torrent }) {
     const now = Math.floor(percent * 1000);
     const nowStr = `${prefix}: ${now / 10}%`;
     const active = props.torrent.rateDownload > 0 || props.torrent.rateUpload > 0;
-    let variant: ProgressBarVariant = "default";
-
-    if (config.values.interface.colorfulProgressbars) {
-        if ((props.torrent.error !== undefined && props.torrent.error > 0) || props.torrent.cachedError !== "") {
-            variant = "red";
-        } else {
-            if (!config.values.interface.animatedProgressbars) {
-                if (active) variant = "green";
-            } else {
-                if (props.torrent.status === Status.stopped && props.torrent.sizeWhenDone > 0) {
-                    if (props.torrent.leftUntilDone === 0) {
-                        variant = "dark-green";
-                    } else {
-                        variant = "yellow";
-                    }
-                } else if (props.torrent.status === Status.seeding) {
-                    variant = "green";
-                } else if (props.torrent.status === Status.queuedToVerify ||
-                    props.torrent.status === Status.queuedToDownload ||
-                    props.torrent.status === Status.queuedToSeed) {
-                    variant = "grey";
-                }
-            }
-        }
-    }
+    const variant = torrentProgressbarVariant(props, config, active);
 
     return (
         <Box w="100%" my="0.5rem">

--- a/src/components/modals/interfacepanel.tsx
+++ b/src/components/modals/interfacepanel.tsx
@@ -22,8 +22,8 @@ import { Checkbox, Grid, MultiSelect, NativeSelect, NumberInput, Textarea, useMa
 import type { UseFormReturnType } from "@mantine/form";
 import ColorChooser from "components/colorchooser";
 import { useGlobalStyleOverrides } from "themehooks";
-import { DeleteTorrentDataOptions, ProgressbarStyleOptions } from "config";
-import type { ProgressbarStyleOption, ColorSetting, DeleteTorrentDataOption, StyleOverrides } from "config";
+import { DeleteTorrentDataOptions } from "config";
+import type { ColorSetting, DeleteTorrentDataOption, StyleOverrides } from "config";
 import { ColorSchemeToggle } from "components/miscbuttons";
 import { Label } from "./common";
 const { TAURI, invoke } = await import(/* webpackChunkName: "taurishim" */"taurishim");
@@ -34,7 +34,8 @@ export interface InterfaceFormValues {
         styleOverrides: StyleOverrides,
         skipAddDialog: boolean,
         deleteTorrentData: DeleteTorrentDataOption,
-        progressbarStyle: ProgressbarStyleOption,
+        animatedProgressbars: boolean,
+        colorfulProgressbars: boolean,
         numLastSaveDirs: number,
         sortLastSaveDirs: boolean,
         preconfiguredLabels: string[],
@@ -146,11 +147,14 @@ export function InterfaceSettigsPanel<V extends InterfaceFormValues>(props: { fo
                 <Checkbox label="Sort download directories list"
                     {...props.form.getInputProps("interface.sortLastSaveDirs", { type: "checkbox" })} />
             </Grid.Col>
-            <Grid.Col span={3}>Progressbars</Grid.Col>
+            <Grid.Col span={3}>Progress bars</Grid.Col>
             <Grid.Col span={3}>
-                <NativeSelect data={ProgressbarStyleOptions as unknown as string[]}
-                    value={props.form.values.interface.progressbarStyle}
-                    onChange={(e) => { setFieldValue("interface.progressbarStyle", e.target.value); }} />
+                <Checkbox label="Colorful"
+                    {...props.form.getInputProps("interface.colorfulProgressbars", { type: "checkbox" })} />
+            </Grid.Col>
+            <Grid.Col span={3}>
+                <Checkbox label="Animated"
+                    {...props.form.getInputProps("interface.animatedProgressbars", { type: "checkbox" })} />
             </Grid.Col>
             <Grid.Col>
                 <MultiSelect

--- a/src/components/progressbar.tsx
+++ b/src/components/progressbar.tsx
@@ -19,7 +19,7 @@
 import "../css/progressbar.css";
 import React from "react";
 
-export type ProgressBarVariant = "default" | "green" | "dark-green" | "red" | "grey";
+export type ProgressBarVariant = "default" | "yellow" | "green" | "dark-green" | "red" | "grey";
 
 interface ProgressBarProps {
     now: number,

--- a/src/components/tables/filetreetable.tsx
+++ b/src/components/tables/filetreetable.tsx
@@ -145,9 +145,9 @@ function PercentBarField(props: TableFieldProps) {
     const config = useContext(ConfigContext);
     const now = props.entry.percent ?? 0;
     let variant: ProgressBarVariant = "default";
-    if (config.values.interface.progressbarStyle === "colorful") {
+    if (config.values.interface.colorfulProgressbars) {
         if (props.entry.want === false) variant = "grey";
-        else if (now === 100) variant = "dark-green";
+        else if (now === 100) variant = "green";
     }
 
     return <ProgressBar now={now} className="white-outline" variant={variant} />;

--- a/src/components/tables/peerstable.tsx
+++ b/src/components/tables/peerstable.tsx
@@ -82,8 +82,14 @@ function PercentField(props: TableFieldProps) {
     return <ProgressBar
         now={now}
         className="white-outline"
-        animate={config.values.interface.progressbarStyle === "animated" && active}
-        variant={config.values.interface.progressbarStyle === "colorful" && active ? "green" : "default"} />;
+        animate={config.values.interface.animatedProgressbars && active}
+        variant={
+            config.values.interface.colorfulProgressbars &&
+            ((config.values.interface.animatedProgressbars && now === 100) ||
+                (!config.values.interface.animatedProgressbars && active))
+                ? "green"
+                : "default"
+        } />;
 }
 
 const Columns = AllFields.map((field): ColumnDef<PeerStats> => {

--- a/src/components/tables/peerstable.tsx
+++ b/src/components/tables/peerstable.tsx
@@ -83,13 +83,8 @@ function PercentField(props: TableFieldProps) {
         now={now}
         className="white-outline"
         animate={config.values.interface.animatedProgressbars && active}
-        variant={
-            config.values.interface.colorfulProgressbars &&
-            ((config.values.interface.animatedProgressbars && now === 100) ||
-                (!config.values.interface.animatedProgressbars && active))
-                ? "green"
-                : "default"
-        } />;
+        variant={config.values.interface.colorfulProgressbars && now === 100 ? "green" : "default"}
+    />;
 }
 
 const Columns = AllFields.map((field): ColumnDef<PeerStats> => {

--- a/src/components/tables/torrenttable.tsx
+++ b/src/components/tables/torrenttable.tsx
@@ -23,8 +23,7 @@ import { useServerTorrentData, useServerRpcVersion, useServerSelectedTorrents } 
 import type { TorrentAllFieldsType, TorrentFieldsType } from "rpc/transmission";
 import { PriorityColors, PriorityStrings, Status, StatusStrings, TorrentMinimumFields } from "rpc/transmission";
 import type { ColumnDef, VisibilityState } from "@tanstack/react-table";
-import { bytesToHumanReadableStr, fileSystemSafeName, modKeyString, pathMapFromServer, secondsToHumanReadableStr, timestampToDateString } from "trutil";
-import type { ProgressBarVariant } from "../progressbar";
+import { bytesToHumanReadableStr, fileSystemSafeName, modKeyString, pathMapFromServer, secondsToHumanReadableStr, timestampToDateString, torrentProgressbarVariant } from "trutil";
 import { ProgressBar } from "../progressbar";
 import type { AccessorFn, CellContext } from "@tanstack/table-core";
 import type { TableSelectReducer } from "./common";
@@ -348,31 +347,7 @@ function PercentBarField(props: TableFieldProps) {
     const config = useContext(ConfigContext);
     const now = props.torrent[props.fieldName] * 100;
     const active = props.torrent.rateDownload > 0 || props.torrent.rateUpload > 0;
-    let variant: ProgressBarVariant = "default";
-
-    if (config.values.interface.colorfulProgressbars) {
-        if ((props.torrent.error !== undefined && props.torrent.error > 0) || props.torrent.cachedError !== "") {
-            variant = "red";
-        } else {
-            if (!config.values.interface.animatedProgressbars) {
-                if (active) variant = "green";
-            } else {
-                if (props.torrent.status === Status.stopped && props.torrent.sizeWhenDone > 0) {
-                    if (props.torrent.leftUntilDone === 0) {
-                        variant = "dark-green";
-                    } else {
-                        variant = "yellow";
-                    }
-                } else if (props.torrent.status === Status.seeding) {
-                    variant = "green";
-                } else if (props.torrent.status === Status.queuedToVerify ||
-                    props.torrent.status === Status.queuedToDownload ||
-                    props.torrent.status === Status.queuedToSeed) {
-                    variant = "grey";
-                }
-            }
-        }
-    }
+    const variant = torrentProgressbarVariant(props, config, active);
 
     return <ProgressBar
         now={now}

--- a/src/components/tables/torrenttable.tsx
+++ b/src/components/tables/torrenttable.tsx
@@ -23,7 +23,7 @@ import { useServerTorrentData, useServerRpcVersion, useServerSelectedTorrents } 
 import type { TorrentAllFieldsType, TorrentFieldsType } from "rpc/transmission";
 import { PriorityColors, PriorityStrings, Status, StatusStrings, TorrentMinimumFields } from "rpc/transmission";
 import type { ColumnDef, VisibilityState } from "@tanstack/react-table";
-import { bytesToHumanReadableStr, fileSystemSafeName, modKeyString, pathMapFromServer, secondsToHumanReadableStr, timestampToDateString, torrentProgressbarVariant } from "trutil";
+import { bytesToHumanReadableStr, fileSystemSafeName, modKeyString, pathMapFromServer, secondsToHumanReadableStr, timestampToDateString, torrentProgressbarStyle } from "trutil";
 import { ProgressBar } from "../progressbar";
 import type { AccessorFn, CellContext } from "@tanstack/table-core";
 import type { TableSelectReducer } from "./common";
@@ -346,14 +346,13 @@ function ByteRateField(props: TableFieldProps) {
 function PercentBarField(props: TableFieldProps) {
     const config = useContext(ConfigContext);
     const now = props.torrent[props.fieldName] * 100;
-    const active = props.torrent.rateDownload > 0 || props.torrent.rateUpload > 0;
-    const variant = torrentProgressbarVariant(props, config, active);
+    const progressbarStyle = torrentProgressbarStyle(props.torrent, config);
 
     return <ProgressBar
         now={now}
         className="white-outline"
-        animate={config.values.interface.animatedProgressbars && active}
-        variant={variant} />;
+        {...progressbarStyle}
+    />;
 }
 
 const Columns = AllFields.map((f): ColumnDef<Torrent> => {

--- a/src/components/tables/torrenttable.tsx
+++ b/src/components/tables/torrenttable.tsx
@@ -349,21 +349,35 @@ function PercentBarField(props: TableFieldProps) {
     const now = props.torrent[props.fieldName] * 100;
     const active = props.torrent.rateDownload > 0 || props.torrent.rateUpload > 0;
     let variant: ProgressBarVariant = "default";
-    if (config.values.interface.progressbarStyle === "colorful") {
-        if ((props.torrent.error !== undefined && props.torrent.error > 0) ||
-            props.torrent.cachedError !== "") variant = "red";
-        else {
-            if (active) variant = "green";
-            else if (props.torrent.status === Status.stopped &&
-                props.torrent.sizeWhenDone > 0 &&
-                props.torrent.leftUntilDone === 0) variant = "dark-green";
+
+    if (config.values.interface.colorfulProgressbars) {
+        if ((props.torrent.error !== undefined && props.torrent.error > 0) || props.torrent.cachedError !== "") {
+            variant = "red";
+        } else {
+            if (!config.values.interface.animatedProgressbars) {
+                if (active) variant = "green";
+            } else {
+                if (props.torrent.status === Status.stopped && props.torrent.sizeWhenDone > 0) {
+                    if (props.torrent.leftUntilDone === 0) {
+                        variant = "dark-green";
+                    } else {
+                        variant = "yellow";
+                    }
+                } else if (props.torrent.status === Status.seeding) {
+                    variant = "green";
+                } else if (props.torrent.status === Status.queuedToVerify ||
+                    props.torrent.status === Status.queuedToDownload ||
+                    props.torrent.status === Status.queuedToSeed) {
+                    variant = "grey";
+                }
+            }
         }
     }
 
     return <ProgressBar
         now={now}
         className="white-outline"
-        animate={config.values.interface.progressbarStyle === "animated" && active}
+        animate={config.values.interface.animatedProgressbars && active}
         variant={variant} />;
 }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -95,11 +95,9 @@ export type SectionsVisibility<S extends string> = Array<{
 export const WindowMinimizeOptions = ["minimize", "hide"] as const;
 export const WindowCloseOptions = ["hide", "close", "quit"] as const;
 export const DeleteTorrentDataOptions = ["default off", "default on", "remember selection"] as const;
-export const ProgressbarStyleOptions = ["plain", "animated", "colorful"] as const;
 export type WindowMinimizeOption = typeof WindowMinimizeOptions[number];
 export type WindowCloseOption = typeof WindowCloseOptions[number];
 export type DeleteTorrentDataOption = typeof DeleteTorrentDataOptions[number];
-export type ProgressbarStyleOption = typeof ProgressbarStyleOptions[number];
 
 export interface ColorSetting {
     color: DefaultMantineColor,
@@ -162,7 +160,8 @@ interface Settings {
         preconfiguredLabels: string[],
         defaultTrackers: string[],
         styleOverrides: StyleOverrides,
-        progressbarStyle: ProgressbarStyleOption,
+        animatedProgressbars: boolean,
+        colorfulProgressbars: boolean,
     },
     configVersion: number,
 }
@@ -285,7 +284,8 @@ const DefaultSettings: Settings = {
             dark: {},
             light: {},
         },
-        progressbarStyle: "animated",
+        animatedProgressbars: true,
+        colorfulProgressbars: true,
     },
     // This field is used to verify config struct compatibility when importing settings
     // Bump this only when incompatible changes are made that cannot be imported into older

--- a/src/config.ts
+++ b/src/config.ts
@@ -160,6 +160,7 @@ interface Settings {
         preconfiguredLabels: string[],
         defaultTrackers: string[],
         styleOverrides: StyleOverrides,
+        progressbarStyle?: string, // deprecated
         animatedProgressbars: boolean,
         colorfulProgressbars: boolean,
     },
@@ -285,7 +286,7 @@ const DefaultSettings: Settings = {
             light: {},
         },
         animatedProgressbars: true,
-        colorfulProgressbars: true,
+        colorfulProgressbars: false,
     },
     // This field is used to verify config struct compatibility when importing settings
     // Bump this only when incompatible changes are made that cannot be imported into older
@@ -314,6 +315,11 @@ export class Config {
             if (this.values.openTabs !== undefined) {
                 this.values.app.openTabs = this.values.openTabs;
                 this.values.openTabs = undefined;
+            }
+            if (this.values.interface.progressbarStyle !== undefined) {
+                this.values.interface.animatedProgressbars = this.values.interface.progressbarStyle === "animated";
+                this.values.interface.colorfulProgressbars = this.values.interface.progressbarStyle === "colorful";
+                this.values.interface.progressbarStyle = undefined;
             }
         } catch (e) {
             console.log(e);

--- a/src/css/progressbar.css
+++ b/src/css/progressbar.css
@@ -17,6 +17,10 @@
     color: white;
 }
 
+.progressbar.yellow>:first-child {
+    background: #fab007;
+}
+
 .progressbar.red>:first-child {
     background: #fa5252;
 }

--- a/src/trutil.ts
+++ b/src/trutil.ts
@@ -238,28 +238,24 @@ export function * chainedIterables<T>(...iterables: Array<Iterable<T>>) {
 export function torrentProgressbarStyle(torrent: Torrent, config: Config) {
     const active = torrent.rateDownload > 0 || torrent.rateUpload > 0;
     const animate = config.values.interface.animatedProgressbars && active;
-    let variant: ProgressBarVariant = "default";
 
+    let variant: ProgressBarVariant = "default";
     if (config.values.interface.colorfulProgressbars) {
         if ((torrent.error !== undefined && torrent.error > 0) || torrent.cachedError !== "") {
             variant = "red";
         } else {
-            if (!config.values.interface.animatedProgressbars) {
-                if (active) variant = "green";
-            } else {
-                if (torrent.status === Status.stopped && torrent.sizeWhenDone > 0) {
-                    if (torrent.leftUntilDone === 0) {
-                        variant = "dark-green";
-                    } else {
-                        variant = "yellow";
-                    }
-                } else if (torrent.status === Status.seeding) {
-                    variant = "green";
-                } else if (torrent.status === Status.queuedToVerify ||
-                    torrent.status === Status.queuedToDownload ||
-                    torrent.status === Status.queuedToSeed) {
-                    variant = "grey";
+            if (torrent.status === Status.stopped && torrent.sizeWhenDone > 0) {
+                if (torrent.leftUntilDone === 0) {
+                    variant = "dark-green";
+                } else {
+                    variant = "yellow";
                 }
+            } else if (torrent.status === Status.seeding) {
+                variant = "green";
+            } else if (torrent.status === Status.queuedToVerify ||
+                torrent.status === Status.queuedToDownload ||
+                torrent.status === Status.queuedToSeed) {
+                variant = "grey";
             }
         }
     }

--- a/src/trutil.ts
+++ b/src/trutil.ts
@@ -235,32 +235,34 @@ export function * chainedIterables<T>(...iterables: Array<Iterable<T>>) {
     for (const iterable of iterables) yield * iterable;
 }
 
-export function torrentProgressbarVariant(props: { torrent: Torrent }, config: Config, active: boolean) {
+export function torrentProgressbarStyle(torrent: Torrent, config: Config) {
+    const active = torrent.rateDownload > 0 || torrent.rateUpload > 0;
+    const animate = config.values.interface.animatedProgressbars && active;
     let variant: ProgressBarVariant = "default";
 
     if (config.values.interface.colorfulProgressbars) {
-        if ((props.torrent.error !== undefined && props.torrent.error > 0) || props.torrent.cachedError !== "") {
+        if ((torrent.error !== undefined && torrent.error > 0) || torrent.cachedError !== "") {
             variant = "red";
         } else {
             if (!config.values.interface.animatedProgressbars) {
                 if (active) variant = "green";
             } else {
-                if (props.torrent.status === Status.stopped && props.torrent.sizeWhenDone > 0) {
-                    if (props.torrent.leftUntilDone === 0) {
+                if (torrent.status === Status.stopped && torrent.sizeWhenDone > 0) {
+                    if (torrent.leftUntilDone === 0) {
                         variant = "dark-green";
                     } else {
                         variant = "yellow";
                     }
-                } else if (props.torrent.status === Status.seeding) {
+                } else if (torrent.status === Status.seeding) {
                     variant = "green";
-                } else if (props.torrent.status === Status.queuedToVerify ||
-                    props.torrent.status === Status.queuedToDownload ||
-                    props.torrent.status === Status.queuedToSeed) {
+                } else if (torrent.status === Status.queuedToVerify ||
+                    torrent.status === Status.queuedToDownload ||
+                    torrent.status === Status.queuedToSeed) {
                     variant = "grey";
                 }
             }
         }
     }
 
-    return variant;
+    return { animate, variant };
 }


### PR DESCRIPTION
Re-implementation of the PR #82 from last year, on top of the recent change [05303b6](https://github.com/openscopeproject/TrguiNG/commit/05303b6c5aff788992bd8790a55e494d415da5a6). Adds the third possibility of using colorful + animated together (color based on status, animated based on activity):

<img width="332" alt="image" src="https://github.com/user-attachments/assets/08ac4e62-dd0e-458e-b6ea-383a0bd1782c">

Takes into account all of @qu1ck's suggestions from the original PR. Fits things to match the existing color scheme and the Transmission app:
- blue for downloading/verifying/magnetizing
- red for error
- green if seeding
- dark green if stopped @ 100%
- yellow if stopped < 100% (to match the stopped icon's color)
- gray if waiting

<img width="216" alt="image" src="https://github.com/user-attachments/assets/5263a1a4-8c54-4cf3-a6a6-25c79f1e09ff">

Only applies if user has both "colorful" and "animated" selected for progress bars in interface settings. Other combinations are unaffected by this.