### PR TITLE
Colorful peers table

### DIFF
--- a/src/components/modals/interfacepanel.tsx
+++ b/src/components/modals/interfacepanel.tsx
@@ -18,7 +18,7 @@
 
 import React, { useCallback, useEffect, useState } from "react";
 import type { ColorScheme } from "@mantine/core";
-import { Checkbox, Grid, MultiSelect, NativeSelect, NumberInput, Textarea, useMantineTheme } from "@mantine/core";
+import { Checkbox, Grid, MultiSelect, NativeSelect, NumberInput, Switch, Textarea, useMantineTheme } from "@mantine/core";
 import type { UseFormReturnType } from "@mantine/form";
 import ColorChooser from "components/colorchooser";
 import { useGlobalStyleOverrides } from "themehooks";
@@ -35,6 +35,7 @@ export interface InterfaceFormValues {
         skipAddDialog: boolean,
         deleteTorrentData: DeleteTorrentDataOption,
         progressbarStyle: ProgressbarStyleOption,
+        colorfulPeers: boolean,
         numLastSaveDirs: number,
         sortLastSaveDirs: boolean,
         preconfiguredLabels: string[],
@@ -151,6 +152,11 @@ export function InterfaceSettigsPanel<V extends InterfaceFormValues>(props: { fo
                 <NativeSelect data={ProgressbarStyleOptions as unknown as string[]}
                     value={props.form.values.interface.progressbarStyle}
                     onChange={(e) => { setFieldValue("interface.progressbarStyle", e.target.value); }} />
+            </Grid.Col>
+            <Grid.Col span={6}>Colorful peers list</Grid.Col>
+            <Grid.Col span={2}>
+                <Switch onLabel="ON" offLabel="OFF" size="xl" styles={{ track: { flexGrow: 1 } }}
+                    {...props.form.getInputProps("interface.colorfulPeers", { type: "checkbox" })} />
             </Grid.Col>
             <Grid.Col>
                 <MultiSelect

--- a/src/components/tables/peerstable.tsx
+++ b/src/components/tables/peerstable.tsx
@@ -22,7 +22,7 @@ import type { Torrent, PeerStats } from "rpc/torrent";
 import { bytesToHumanReadableStr } from "trutil";
 import { TrguiTable, useStandardSelect } from "./common";
 import { ProgressBar } from "components/progressbar";
-import { Flex } from "@mantine/core";
+import { Badge, Flex } from "@mantine/core";
 import { ConfigContext } from "config";
 const { TAURI } = await import(/* webpackChunkName: "taurishim" */"taurishim");
 if (TAURI) await import(/* webpackChunkName: "flag-icons" */"flagsshim");
@@ -48,10 +48,10 @@ const AllFields: TableField[] = [
     { name: "progress", label: "Have", component: PercentField },
     { name: "rateToPeer", label: "Up speed", component: ByteRateField },
     { name: "rateToClient", label: "Down speed", component: ByteRateField },
-    { name: "cachedEncrypted", label: "Encrypted" },
-    { name: "cachedFrom", label: "From" },
-    { name: "cachedConnection", label: "Connection" },
-    { name: "cachedProtocol", label: "Protocol" },
+    { name: "cachedEncrypted", label: "🔒" },
+    { name: "cachedFrom", label: "From", component: FromField },
+    { name: "cachedConnection", label: "Connection", component: ConnectionField },
+    { name: "cachedProtocol", label: "Protocol", component: ProtocolField },
     { name: "cachedStatus", label: "Status" },
 ];
 
@@ -63,6 +63,51 @@ function CountryField(props: TableFieldProps) {
         {iso !== undefined && <span className={`fi fi-${iso.toLowerCase()}`} />}
         <span>{props.entry.cachedCountryName}</span>
     </Flex>;
+}
+
+function ProtocolField(props: TableFieldProps) {
+    const config = useContext(ConfigContext);
+    const protocol = props.entry.cachedProtocol;
+    if (config.values.interface.colorfulPeers) {
+        return <Badge
+            radius="md"
+            variant="filled"
+            bg={protocol === "µTP" ? "green" : "blue"}>
+            {protocol === "µTP" ? "UTP" : protocol}
+        </Badge>;
+    } else {
+        return <div>{protocol}</div>;
+    }
+}
+
+function ConnectionField(props: TableFieldProps) {
+    const config = useContext(ConfigContext);
+    const connection = props.entry.cachedConnection;
+    if (config.values.interface.colorfulPeers) {
+        return <Badge
+            radius="md"
+            variant="filled"
+            bg={connection === "incoming" ? "green" : "blue"}>
+            {connection}
+        </Badge>;
+    } else {
+        return <div>{connection}</div>;
+    }
+}
+
+function FromField(props: TableFieldProps) {
+    const config = useContext(ConfigContext);
+    const from = props.entry.cachedFrom;
+    if (config.values.interface.colorfulPeers) {
+        return <Badge
+            radius="md"
+            variant="filled"
+            bg={from === "DHT" ? "orange.7" : from === "PEX" ? "yellow.6" : "blue"}>
+            {from}
+        </Badge>;
+    } else {
+        return <div>{from}</div>;
+    }
 }
 
 function ByteRateField(props: TableFieldProps) {

--- a/src/config.ts
+++ b/src/config.ts
@@ -163,6 +163,7 @@ interface Settings {
         defaultTrackers: string[],
         styleOverrides: StyleOverrides,
         progressbarStyle: ProgressbarStyleOption,
+        colorfulPeers: boolean,
     },
     configVersion: number,
 }
@@ -285,6 +286,7 @@ const DefaultSettings: Settings = {
             light: {},
         },
         progressbarStyle: "animated",
+        colorfulPeers: true,
     },
     // This field is used to verify config struct compatibility when importing settings
     // Bump this only when incompatible changes are made that cannot be imported into older

--- a/src/rpc/torrent.ts
+++ b/src/rpc/torrent.ts
@@ -191,7 +191,7 @@ async function processPeerStats(peer: PeerStatsBase, lookupIps: boolean, client:
 
     return {
         ...peer,
-        cachedEncrypted: flags.includes("E") ? "yes" : "no",
+        cachedEncrypted: flags.includes("E") ? "🔒" : "",
         cachedFrom,
         cachedConnection: flags.includes("I") ? "incoming" : "outgoing",
         cachedProtocol: flags.includes("T") ? "µTP" : "TCP",


### PR DESCRIPTION
Implements a more visually colorful peers table instead of just bare text. Only applies if the corresponding setting is turned on. I use this for quicker discernment in a big list of peers as opposed to the plain text. Thought others might find it appealing too.

<img width="335" alt="image" src="https://github.com/user-attachments/assets/d298f14b-d2cd-498a-b47d-6ca1e155ec5f">

Goes from this:

<img width="593" alt="image" src="https://github.com/user-attachments/assets/a8aaeed5-aa87-47bf-9af2-8d9e2abaef09">

to:

<img width="594" alt="Screenshot 2024-08-06 at 10 05 26 PM" src="https://github.com/user-attachments/assets/f9f7d1cf-806a-486e-a6f9-85b2d6471d5f">

Uses blue as the badge color for the most "default" option (from: tracker, connection: outgoing, protocol: TCP).
Uses green as the more "good" option when there's only 2 possible options (connection: incoming, protocol: μTP).
Uses yellow and red for the more "good" options when there are 3 possible options, like for "from": blue for the default of tracker, yellow for PEX, and red for DHT.

Also, uses a lock icon for encryption instead of just saying "yes" and "no". This is not toggleable, since the existing structure would need some refactoring, but let me know if that should be toggled too.