### PR TITLE
Add errorString "Tracker error" column

### DIFF
--- a/src/components/tables/torrenttable.tsx
+++ b/src/components/tables/torrenttable.tsx
@@ -138,6 +138,13 @@ const AllFields: readonly TableField[] = [
         columnId: "trackerStatus",
         accessorFn: (t) => t.cachedTrackerStatus,
     },
+    {
+        name: "errorString",
+        label: "Error",
+        component: ErrorField,
+        columnId: "error",
+        accessorFn: (t) => t.cachedError,
+    },
     { name: "doneDate", label: "Completed on", component: DateField },
     { name: "activityDate", label: "Last active", component: DateDiffField },
     { name: "downloadDir", label: "Path", component: StringField },
@@ -271,6 +278,10 @@ export function TrackerField(props: TableFieldProps) {
 
 function TrackerStatusField(props: TableFieldProps) {
     return <div>{props.torrent.cachedTrackerStatus}</div>;
+}
+
+function ErrorField(props: TableFieldProps) {
+    return <div>{props.torrent.cachedError}</div>;
 }
 
 function PriorityField(props: TableFieldProps) {

--- a/src/config.ts
+++ b/src/config.ts
@@ -187,6 +187,7 @@ const DefaultColumnVisibility: Partial<Record<TableName, VisibilityState>> = {
         "file-count": false,
         pieceCount: false,
         metadataPercentComplete: false,
+        error: false,
     },
     peers: {
         flagStr: false,


### PR DESCRIPTION
Closes #217 

This PR implements a new column "Tracker error" which is the literal `errorString` from a torrent, representing any error string returned by the tracker to compliment the existing "Tracker status" field.

Built, tested and, confirmed it worked as expected