### PR TITLE
Add trgui-ng-bin to conflicts in pkgbuild template

### DIFF
--- a/ci/generate_pkgbuild.py
+++ b/ci/generate_pkgbuild.py
@@ -31,7 +31,7 @@ arch=('x86_64')
 license=('AGPL-3.0')
 depends=('alsa-lib' 'cairo' 'desktop-file-utils' 'fontconfig' 'gdk-pixbuf2' 'glib2' 'gtk3' 'hicolor-icon-theme' 'libayatana-appindicator' 'libsoup' 'openssl' 'webkit2gtk')
 makedepends=('rust>=1.70.0' 'nodejs>=16.0.0' 'npm' 'git')
-conflicts=('trgui-ng-git')
+conflicts=('trgui-ng-git' 'trgui-ng-bin')
 source=("git+https://github.com/openscopeproject/TrguiNG#tag=v$pkgver"
         "https://github.com/openscopeproject/TrguiNG/releases/download/v$pkgver/dbip.mmdb"
         "TrguiNG.desktop"::"https://raw.githubusercontent.com/flathub/org.openscopeproject.TrguiNG/master/org.openscopeproject.TrguiNG.desktop")


### PR DESCRIPTION
Someone published a prebuilt package for trgui-ng on the AUR. This needs to be added to conflicts to prevent issues. I've already updated the AUR itself.