### PR TITLE
Update generate_pkgbuild.py

### DIFF
--- a/ci/generate_pkgbuild.py
+++ b/ci/generate_pkgbuild.py
@@ -33,7 +33,7 @@ pkgdesc='Remote GUI for Transmission torrent daemon'
 url="https://github.com/openscopeproject/TrguiNG"
 arch=('x86_64')
 license=('AGPL-3.0')
-depends=('alsa-lib' 'cairo' 'desktop-file-utils' 'fontconfig' 'gdk-pixbuf2' 'glib2' 'gtk3' 'hicolor-icon-theme' 'libayatana-appindicator' 'libsoup' 'openssl' 'webkit2gtk' 'webkit2gtk-4.1')
+depends=('alsa-lib' 'cairo' 'desktop-file-utils' 'fontconfig' 'gdk-pixbuf2' 'glib2' 'gtk3' 'hicolor-icon-theme' 'libayatana-appindicator' 'libsoup' 'openssl' 'webkit2gtk-4.1')
 makedepends=('rust>=1.77.2' 'nodejs>=16.0.0' 'npm' 'git')
 conflicts=('trgui-ng-git' 'trgui-ng-bin')
 source=("git+https://github.com/openscopeproject/TrguiNG#tag=v$pkgver"

--- a/ci/generate_pkgbuild.py
+++ b/ci/generate_pkgbuild.py
@@ -33,7 +33,7 @@ pkgdesc='Remote GUI for Transmission torrent daemon'
 url="https://github.com/openscopeproject/TrguiNG"
 arch=('x86_64')
 license=('AGPL-3.0')
-depends=('alsa-lib' 'cairo' 'desktop-file-utils' 'fontconfig' 'gdk-pixbuf2' 'glib2' 'gtk3' 'hicolor-icon-theme' 'libayatana-appindicator' 'libsoup' 'openssl' 'webkit2gtk')
+depends=('alsa-lib' 'cairo' 'desktop-file-utils' 'fontconfig' 'gdk-pixbuf2' 'glib2' 'gtk3' 'hicolor-icon-theme' 'libayatana-appindicator' 'libsoup' 'openssl' 'webkit2gtk' 'webkit2gtk-4.1')
 makedepends=('rust>=1.77.2' 'nodejs>=16.0.0' 'npm' 'git')
 conflicts=('trgui-ng-git' 'trgui-ng-bin')
 source=("git+https://github.com/openscopeproject/TrguiNG#tag=v$pkgver"
@@ -63,7 +63,7 @@ package() {
     install -dm755 "$pkgdir/usr/lib/trgui-ng"
     install -dm755 "$pkgdir/usr/share/icons/hicolor/32x32/apps"
     install -dm755 "$pkgdir/usr/share/icons/hicolor/128x128/apps"
-    install -Dm755 "$srcdir/TrguiNG/src-tauri/target/release/trgui-ng" "$pkgdir/usr/bin/trgui-ng"
+    install -Dm755 "$srcdir/TrguiNG/src-tauri/target/release/TrguiNG" "$pkgdir/usr/bin/trgui-ng"
     install -Dm644 "$srcdir/TrguiNG/src-tauri/dbip.mmdb" "$pkgdir/usr/lib/trgui-ng/dbip.mmdb"
     install -Dm755 "$srcdir/TrguiNG.desktop" "$pkgdir/usr/share/applications/TrguiNG.desktop"
     install -Dm644 "$srcdir/TrguiNG/src-tauri/icons/32x32.png" "$pkgdir/usr/share/icons/hicolor/32x32/apps/trgui-ng.png"


### PR DESCRIPTION
1) I discovered a new dependency, webkit2gtk-4.1. the git version will not build without it. I assume it belongs in depends and not makedepends (?)

2) after move to tauri2, the executable has changed from trgui-ng to TrguiNG. I have changed the package function to reflect this. Note, also, that the desktop file still has trgui-ng on it, since we're getting it from flathub; therefore, when packaging, i have changed the filename back to trgui-ng on the git package for now. Befoore publishing the next stable version, don't forget to change the desktop file.