### PR TITLE
Don't require `git` at build time

### DIFF
--- a/webpack.common.mjs
+++ b/webpack.common.mjs
@@ -29,9 +29,9 @@ export const __dirname = url.fileURLToPath(new URL(".", import.meta.url));
 const tsConfig = JSON.parse(await readFile("./tsconfig.json"));
 const tauriConf = JSON.parse(await readFile("./src-tauri/tauri.conf.json"));
 
-const gitVersion = execaSync("git", ["describe", "--tags", "--dirty", "--always"]);
+const gitVersion = process.env.TRGUING_VERSION ?? execaSync("git", ["describe", "--tags", "--dirty", "--always"]).stdout;
 const versionInfo = `{
-    "gitVersion": "${gitVersion.stdout}",
+    "gitVersion": "${gitVersion}",
     "backendVersion": "${tauriConf.version}",
     "buildDate": ${Date.now()}
 }`;


### PR DESCRIPTION
Allow one to set the package version without relying on `git` being available at build time, or the package to even be in a git repository.