### PR TITLE
Fix: Update TorrentLocation disabled logic to check pre-defined directories

### DIFF
--- a/src/components/modals/common.tsx
+++ b/src/components/modals/common.tsx
@@ -182,7 +182,14 @@ export function TorrentLocation(props: LocationData) {
                     <Menu position="left-start" withinPortal returnFocus
                         middlewares={{ shift: true, flip: false }} offset={{ mainAxis: -20, crossAxis: 30 }}>
                         <Menu.Target>
-                            <ActionIcon py="md" disabled={props.disabled === true || props.lastPaths.length === 0}>
+                            <ActionIcon
+                                py="md"
+                                disabled={
+                                    props.disabled === true ||
+                                    (props.lastPaths.length === 0 &&
+                                        config.values.interface.preconfiguredDirs.length === 0)
+                                }
+                            >
                                 <Icon.ClockHistory size="16" />
                             </ActionIcon>
                         </Menu.Target>


### PR DESCRIPTION
### Problem
The "Torrent Location" button was incorrectly disabled when the `lastPaths` (download history) list was empty. 

This behavior prevented users from selecting a directory from their **Pre-configured directories** if they hadn't manually entered a path before. Even if pre-defined paths existed, the button remained unclickable because the logic only checked for `lastPaths`.

### Solution
Updated the `disabled` condition in the `TorrentLocation` component.

**Logic Change:**
- **Before:** Disabled if `lastPaths` is empty.
- **After:** Disabled if BOTH `lastPaths` AND `preconfiguredDirs` are empty.

Now, users can access the directory selection menu to choose a pre-configured path even if their download history is empty.

### Related Issue
https://github.com/ManuZhu0728/TrguiNG/issues/6