### PR TITLE
fix: `tauri://file-drop` never triggered. 

### DIFF
--- a/src/components/modals/servermodals.tsx
+++ b/src/components/modals/servermodals.tsx
@@ -106,7 +106,7 @@ const ServerModals = React.forwardRef<ModalCallbacks, ServerModalsProps>(functio
     useEffect(() => {
         if (TAURI) {
             const dropResult = appWindow.onDragDropEvent((event) => {
-                if (event.payload.type === 'drop') {
+                if (event.payload.type === "drop") {
                     const files = event.payload.paths.filter((path) => path.toLowerCase().endsWith(".torrent"));
                     if (files.length > 0) enqueue(files);
                 }

--- a/src/taurishim.ts
+++ b/src/taurishim.ts
@@ -18,7 +18,7 @@
 
 import type { EventCallback } from "@tauri-apps/api/event";
 import type { CloseRequestedEvent, PhysicalPosition, PhysicalSize } from "@tauri-apps/api/window";
-import {DragDropEvent} from "@tauri-apps/api/webview";
+import type { DragDropEvent } from "@tauri-apps/api/webview";
 
 export const TAURI = Object.prototype.hasOwnProperty.call(window, "__TAURI__");
 const realAppWindow = TAURI ? (await import(/* webpackMode: "lazy-once" */ "@tauri-apps/api/window")).getCurrentWindow() : undefined;


### PR DESCRIPTION
tauri://file-drop is no longer supported in the new version; use onDragDropEvent.